### PR TITLE
Mapping files for TD 1.0 and 1.1

### DIFF
--- a/td/v1.1/README.md
+++ b/td/v1.1/README.md
@@ -5,7 +5,7 @@ Folder for resources that are next to the specification such as ontologies, cont
 TD 1.1 contains JSON-LD context, JSON Schemas for TDs and TMs and also ontology files that are shared by TD 1.0 and TD 2.0 users.
 
 | W3C URL | GitHub URL to redirect to | Content Type | Note |
-| ------- | ---------- | ------------ |
+| ------- | ---------- | ------------ | ------------ |
 | `https://www.w3.org/2019/wot/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl` | `text/turtle` | |
 | `https://www.w3.org/2019/wot/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
 | `https://www.w3.org/2019/wot/json-schema` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/json-schema.ttl` | `text/turtle` | |

--- a/td/v1.1/README.md
+++ b/td/v1.1/README.md
@@ -3,3 +3,21 @@
 Folder for resources that are next to the specification such as ontologies, context files and validation files.
 
 TD 1.1 contains JSON-LD context, JSON Schemas for TDs and TMs and also ontology files that are shared by TD 1.0 and TD 2.0 users.
+
+| W3C URL | GitHub URL to redirect to | Content Type | Note |
+| ------- | ---------- | ------------ |
+| `https://www.w3.org/2019/wot/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl` | `text/turtle` | |
+| `https://www.w3.org/2019/wot/td` (same as above) | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/2019/wot/json-schema` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/json-schema.ttl` | `text/turtle` | |
+| `https://www.w3.org/2019/wot/json-schema` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/jsonschema.html` | `text/html`| same as above but different content type |
+| `https://www.w3.org/2019/wot/security` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/wotsec.ttl` | `text/turtle` | |
+| `https://www.w3.org/2019/wot/security` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/wotsec.html` | `text/html`|  same as above but different content type |
+| `https://www.w3.org/2019/wot/hypermedia` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/hctl.ttl` | `text/turtle` | |
+| `https://www.w3.org/2019/wot/hypermedia` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/hctl.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/2022/wot/td/v1.1` | `https://w3c.github.io/wot-resources/td/v1.1/context/td-context-1.1.jsonld` | `application/ld+json`| |
+| `https://www.w3.org/2022/wot/tm` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/tm.ttl` | `text/turtle`| |
+| `https://www.w3.org/2022/wot/td-schema/v1.1` | `https://w3c.github.io/wot-resources/td/v1.1/validation/td-json-schema-validation.json` | `application/json` | |
+| `https://www.w3.org/2022/wot/tm-schema/v1.1` | `https://w3c.github.io/wot-resources/td/v1.1/validation/tm-json-schema-validation.json` | `application/json` | |
+
+
+**Note:** The group had decided in the TD 1.1 work that the ontologies behind `https://www.w3.org/2019/wot/td`, `https://www.w3.org/2019/wot/json-schema`, `https://www.w3.org/2019/wot/security` and `https://www.w3.org/2019/wot/hypermedia` change to the 1.1 version. Thus, the same files are used for 1.0 and 1.1 ontologies and that is the reason why old URLs are also mapped in this folder and readme.

--- a/td/v1.1/README.md
+++ b/td/v1.1/README.md
@@ -7,7 +7,7 @@ TD 1.1 contains JSON-LD context, JSON Schemas for TDs and TMs and also ontology 
 | W3C URL | GitHub URL to redirect to | Content Type | Note |
 | ------- | ---------- | ------------ |
 | `https://www.w3.org/2019/wot/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl` | `text/turtle` | |
-| `https://www.w3.org/2019/wot/td` (same as above) | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/2019/wot/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
 | `https://www.w3.org/2019/wot/json-schema` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/json-schema.ttl` | `text/turtle` | |
 | `https://www.w3.org/2019/wot/json-schema` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/jsonschema.html` | `text/html`| same as above but different content type |
 | `https://www.w3.org/2019/wot/security` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/wotsec.ttl` | `text/turtle` | |

--- a/td/v1/README.md
+++ b/td/v1/README.md
@@ -4,3 +4,10 @@ Folder for resources that are next to the specification such as ontologies, cont
 
 TD 1.0 only contains the context file and the JSON Schema for validation.
 Ontology files are simply taken over by the 1.1 version and they can be used by TD 1.0 users.
+
+| W3C URL | GitHub URL to redirect to | Content Type | Note |
+| ------- | ---------- | ------------ |
+| `https://www.w3.org/2019/wot/td-schema/v1` | `https://w3c.github.io/wot-resources/td/v1/validation/td-json-schema-validation.json` | `application/json`| |
+| `https://www.w3.org/2019/wot/td/v1` | `https://w3c.github.io/wot-resources/td/v1/context/td-context-1.1.jsonld` | `application/ld+json` | |
+
+**Note:** The group had decided in the TD 1.1 work that the ontologies behind `https://www.w3.org/2019/wot/td`, `https://www.w3.org/2019/wot/json-schema`, `https://www.w3.org/2019/wot/security` and `https://www.w3.org/2019/wot/hypermedia` change to the 1.1 version. Thus, the same files are used for 1.0 and 1.1 ontologies and that is the reason why they do not appear here.

--- a/td/v1/README.md
+++ b/td/v1/README.md
@@ -6,7 +6,7 @@ TD 1.0 only contains the context file and the JSON Schema for validation.
 Ontology files are simply taken over by the 1.1 version and they can be used by TD 1.0 users.
 
 | W3C URL | GitHub URL to redirect to | Content Type | Note |
-| ------- | ---------- | ------------ |
+| ------- | ---------- | ------------ | ------------ |
 | `https://www.w3.org/2019/wot/td-schema/v1` | `https://w3c.github.io/wot-resources/td/v1/validation/td-json-schema-validation.json` | `application/json`| |
 | `https://www.w3.org/2019/wot/td/v1` | `https://w3c.github.io/wot-resources/td/v1/context/td-context-1.1.jsonld` | `application/ld+json` | |
 


### PR DESCRIPTION
This copies over the structure from https://github.com/w3c/wot-thing-description/blob/main/NAMESPACES.md while also adding a note column.

I have tested all the URLs we are redirecting to.