### PR TITLE
HTML file placeholder for discovery ontology

### DIFF
--- a/discovery/v1/README.md
+++ b/discovery/v1/README.md
@@ -14,5 +14,6 @@ as a relative URL, e.g. "context/discovery-core.jsonld" can be found at
 | https://www.w3.org/2022/wot/discovery | [context/discovery-core.jsonld](https://w3c.github.io/wot-resources/discovery/v1/context/discovery-core.jsonld) | application/ld+json; charset=utf-8 |
 | https://www.w3.org/2022/wot/discovery-did | [context/discovery-did.jsonld](https://w3c.github.io/wot-resources/discovery/v1/context/discovery-did.jsonld) | application/ld+json; charset=utf-8 |
 | https://www.w3.org/2022/wot/discovery-ontology | [ontology/discovery-ontology.ttl](https://w3c.github.io/wot-resources/discovery/v1/ontology/discovery-ontology.ttl) | text/turtle; charset=utf-8 |
+|                                                | [ontology/discovery-ontology.html](https://w3c.github.io/wot-resources/discovery/v1/ontology/discovery-ontology.html) | text/html; charset=utf-8 |
 | https://www.w3.org/2022/wot/discovery/model/directory | [model/directory.tm.jsonld](https://w3c.github.io/wot-resources/discovery/v1/model/directory.tm.jsonld) | application/tm+json; charset=utf-8 |
 | https://www.w3.org/2022/wot/discovery/validation/td-discovery-extensions-json-schema | [validation/td-discovery-extensions-json-schema.json](https://w3c.github.io/wot-resources/discovery/v1/validation/td-discovery-extensions-json-schema.json) | application/json; charset=utf-8 |

--- a/discovery/v1/ontology/discovery-ontology.html
+++ b/discovery/v1/ontology/discovery-ontology.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8'>
+    <title>Web of Things (WoT) Discovery Ontology</title>
+</head>
+
+<body>
+    <h1>Web of Things (WoT) Discovery Ontology</h1>
+    <section>
+        <h2>Work in Progress</h2>
+        <p>An HTML rendering of the Web of Things (WoT) Discovery
+        ontology is under development.  In the meantime, please
+        refer to the Turtle (ttl) file which can be fetched from this same
+        URL, 
+        <a href="https://www.w3.org/2022/wot/discovery-ontology">https://www.w3.org/2022/wot/discovery-ontology</a>,
+        but using the <code>text/turtle</code> Content-Type.</p>
+        <p>You can also find this file on github at
+        <a href="https://github.com/w3c/wot-resources/blob/main/discovery/v1/ontology/discovery-ontology.ttl">https://github.com/w3c/wot-resources/blob/main/discovery/v1/ontology/discovery-ontology.ttl</a>.</p>
+    </section>
+</body>
+
+</html>


### PR DESCRIPTION
- Placeholder for discovery ontology in HTML form
- Aligned with https://github.com/w3c/wot-discovery/pull/532
- Merging immediately as discussed in Discovery call so it can be published with other resources (want to avoid 404 error)
- README also updated