### PR TITLE
refactor: Align Readme to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
-# wot-resources
-Repository for the resources like ontologies for WoT specifications
+<p align="center">
+  <a href="https://w3.org/wot">
+    <img alt="Web of Things Homepage" src="https://www.w3.org/WoT/IG/wiki/images/8/8f/WOT-hz.svg" width="300" />
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://w3c.social/@wot">
+    <img alt="Follow on Mastodon" src="https://img.shields.io/mastodon/follow/111609289932468076?domain=https%3A%2F%2Fw3c.social"></a>
+  <a href="https://twitter.com/W3C_WoT">
+    <img alt="X (formerly Twitter) Follow" src="https://img.shields.io/twitter/follow/W3C_WoT"></a>
+  <a href="https://stackoverflow.com/questions/tagged/web-of-things">
+    <img alt="Stack Exchange questions" src="https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic"></a>
+</p>
+
+# Web of Things (WoT) Resources
+
+Repository for the resources like ontologies for WoT specifications.
 
 * [TD v1](td/v1/README.md)
 * [TD v1.1](td/v1.1/README.md)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 # Web of Things (WoT) Resources
 
+General information about the Web of Things can be found on https://www.w3.org/WoT/.
+  
+---
+
 Repository for the resources like ontologies for WoT specifications.
 
 * [TD v1](td/v1/README.md)


### PR DESCRIPTION
Upgrades the readme of this repo with the guidelines defined in the [general template](https://github.com/w3c/wot/blob/main/README.template.md).

Note: 
- removed the REC/ED links etc since they do not apply
- other parts like calls etc don't apply either --> rather simple addition of the header