### PR TITLE
WoT Next Resources

### DIFF
--- a/td/next/README.md
+++ b/td/next/README.md
@@ -1,0 +1,22 @@
+# WoT TD Next Resources
+
+While the other folders contain the resources to be used in the Recommendation stage, during the development of new TD specification versions, such resources are not stable and are found in [the GitHub repository of the specification](https://github.com/w3c/wot-thing-description).
+Thus, this folder only contains this readme that documents the URLs that are forwarded.
+
+Currently, these resources are JSON-LD context, JSON Schemas for TDs and TMs and also ontology files.
+
+| W3C URL | GitHub URL to redirect to | Content Type | Note |
+| ------- | ---------- | ------------ | ------------ |
+| `https://www.w3.org/ns/wot-next` | `https://w3c.github.io/wot-thing-description/context/td-context-1.1.jsonld` | `application/ld+json`| |
+| `https://www.w3.org/ns/wot-next/tm` | `https://w3c.github.io/wot-thing-description/ontology/tm.ttl` | `text/turtle`| |
+| `https://www.w3.org/ns/wot-next/tm` | `https://w3c.github.io/wot-thing-description/ontology/tm.html` | `text/html`| |
+| `https://www.w3.org/ns/wot-next/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/ns/wot-next/json-schema` | `https://w3c.github.io/wot-thing-description/ontology/jsonschema.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/json-schema` | `https://w3c.github.io/wot-thing-description/ontology/jsonschema.html` | `text/html`| same as above but different content type |
+| `https://www.w3.org/ns/wot-next/security` | `https://w3c.github.io/wot-thing-description/ontology/wotsec.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/security` | `https://w3c.github.io/wot-thing-description/ontology/wotsec.html` | `text/html`|  same as above but different content type |
+| `https://www.w3.org/ns/wot-next/hypermedia` | `https://w3c.github.io/wot-thing-description/ontology/hctl.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/hypermedia` | `https://w3c.github.io/wot-thing-description/ontology/hctl.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/ns/wot-next/td-schema` | `https://w3c.github.io/wot-thing-description/validation/td-json-schema-validation.json` | `application/json` | |
+| `https://www.w3.org/ns/wot-next/tm-schema` | `https://w3c.github.io/wot-thing-description/validation/tm-json-schema-validation.json` | `application/json` | |

--- a/td/next/README.md
+++ b/td/next/README.md
@@ -7,16 +7,16 @@ Currently, these resources are JSON-LD context, JSON Schemas for TDs and TMs and
 
 | W3C URL | GitHub URL to redirect to | Content Type | Note |
 | ------- | ---------- | ------------ | ------------ |
-| `https://www.w3.org/ns/wot-next` | `https://w3c.github.io/wot-thing-description/context/td-context-1.1.jsonld` | `application/ld+json`| |
-| `https://www.w3.org/ns/wot-next/tm` | `https://w3c.github.io/wot-thing-description/ontology/tm.ttl` | `text/turtle`| |
-| `https://www.w3.org/ns/wot-next/tm` | `https://w3c.github.io/wot-thing-description/ontology/tm.html` | `text/html`| |
-| `https://www.w3.org/ns/wot-next/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl` | `text/turtle` | |
-| `https://www.w3.org/ns/wot-next/td` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
-| `https://www.w3.org/ns/wot-next/json-schema` | `https://w3c.github.io/wot-thing-description/ontology/jsonschema.ttl` | `text/turtle` | |
-| `https://www.w3.org/ns/wot-next/json-schema` | `https://w3c.github.io/wot-thing-description/ontology/jsonschema.html` | `text/html`| same as above but different content type |
-| `https://www.w3.org/ns/wot-next/security` | `https://w3c.github.io/wot-thing-description/ontology/wotsec.ttl` | `text/turtle` | |
-| `https://www.w3.org/ns/wot-next/security` | `https://w3c.github.io/wot-thing-description/ontology/wotsec.html` | `text/html`|  same as above but different content type |
-| `https://www.w3.org/ns/wot-next/hypermedia` | `https://w3c.github.io/wot-thing-description/ontology/hctl.ttl` | `text/turtle` | |
-| `https://www.w3.org/ns/wot-next/hypermedia` | `https://w3c.github.io/wot-thing-description/ontology/hctl.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/ns/wot-next/td` | `https://w3c.github.io/wot-thing-description/context/td-context-1.1.jsonld` | `application/ld+json`| |
+| `https://www.w3.org/ns/wot-next/tm-ontology` | `https://w3c.github.io/wot-thing-description/ontology/tm.ttl` | `text/turtle`| |
+| `https://www.w3.org/ns/wot-next/tm-ontology` | `https://w3c.github.io/wot-thing-description/ontology/tm.html` | `text/html`| |
+| `https://www.w3.org/ns/wot-next/td-ontology` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/td-ontology` | `https://w3c.github.io/wot-resources/td/v1.1/ontology/td.html` | `text/html` |  same as above but different content type |
+| `https://www.w3.org/ns/wot-next/json-schema-ontology` | `https://w3c.github.io/wot-thing-description/ontology/jsonschema.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/json-schema-ontology` | `https://w3c.github.io/wot-thing-description/ontology/jsonschema.html` | `text/html`| same as above but different content type |
+| `https://www.w3.org/ns/wot-next/security-ontology` | `https://w3c.github.io/wot-thing-description/ontology/wotsec.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/security-ontology` | `https://w3c.github.io/wot-thing-description/ontology/wotsec.html` | `text/html`|  same as above but different content type |
+| `https://www.w3.org/ns/wot-next/hypermedia-ontology` | `https://w3c.github.io/wot-thing-description/ontology/hctl.ttl` | `text/turtle` | |
+| `https://www.w3.org/ns/wot-next/hypermedia-ontology` | `https://w3c.github.io/wot-thing-description/ontology/hctl.html` | `text/html` |  same as above but different content type |
 | `https://www.w3.org/ns/wot-next/td-schema` | `https://w3c.github.io/wot-thing-description/validation/td-json-schema-validation.json` | `application/json` | |
 | `https://www.w3.org/ns/wot-next/tm-schema` | `https://w3c.github.io/wot-thing-description/validation/tm-json-schema-validation.json` | `application/json` | |


### PR DESCRIPTION
I am putting the forever experimental URLs for the TD resources. I am not entirely satisfied due to reasons noted below and I would like to reach an async agreement before Wednesday. @relu91 @mahdanoura can you provide your opinion?

The reasoning behind my choice:

1. In TD 1.0 we seem to have chosen `https://www.w3.org/2019/wot/td` for the TD ontology (always same for TTL and HTML) and `https://www.w3.org/2019/wot/td/v1` for the JSON-LD context. This is a bit weird imo but I don't remember why. We can do something like `https://www.w3.org/ns/td-next` for the context and `https://www.w3.org/ns/td-next/td` for the ontology
2. Discovery has `https://www.w3.org/2022/wot/discovery` and `https://www.w3.org/2022/wot/discovery-ontology` . That was kind of my inspiration. I thought adding `-context` prefix to the context URI but that is always found inside `@context` and is always more obvious (not the best argument...)
3. I thought about doing content negotiation but people would the ontology in HTML when they open the context uri in the browser. That would mean `https://www.w3.org/ns/wot-next/td` would be the only URL for the context (`application/ld+json`), for the TD Ontology TTL (`text/turtle`) and TD Ontology HTML (`text/html`).
4. It would be nice to _own_ the `wot-next` resource contents for all our specs